### PR TITLE
Use declarative setuptools configuration setup.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include versioneer.py
+include pyproject.toml README.rst versioneer.py
 include bmipy/_version.py

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ pretty: ## reformat files to make them look pretty
 	black setup.py bmipy
 
 test: ## run tests quickly with the default Python
-	py.test
+	pytest
 
 test-all: ## run tests on every Python version with tox
 	tox
@@ -82,9 +82,8 @@ release: dist ## package and upload a release
 	twine upload dist/*
 
 dist: clean ## builds source and wheel package
-	python setup.py sdist
-	python setup.py bdist_wheel
+	python -m build
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	pip install .

--- a/README.rst
+++ b/README.rst
@@ -1,34 +1,27 @@
-.. raw:: html
-
-   <p align="left">
-
-   <a href="https://zenodo.org/badge/latestdoi/179283861">
-	 <img src="https://zenodo.org/badge/179283861.svg"
-	 alt="DOI"></a>
-
-   <a href='https://github.com/csdms/bmi-python/actions/workflows/test.yml'>
-	 <img src='https://github.com/csdms/bmi-python/actions/workflows/test.yml/badge.svg'
-	 alt='Build Status'></a>
-
-   <a href='https://anaconda.org/conda-forge/bmipy'>
-	 <img src='https://anaconda.org/conda-forge/bmipy/badges/version.svg'
-	 alt='Anaconda-Server Badge'></a>
-
-   <a href='https://anaconda.org/conda-forge/bmipy'>
-	 <img src='https://anaconda.org/conda-forge/bmipy/badges/platforms.svg'
-	 alt='Anaconda-Server Badge'></a>
-
-   <a href='https://anaconda.org/conda-forge/bmipy'>
-	 <img src='https://anaconda.org/conda-forge/bmipy/badges/downloads.svg'
-	 alt='Anaconda-Server Badge'></a>
-
-   </p>
-
-
 BMI for Python
 ==============
 
 Python bindings for the CSDMS `Basic Model Interface <https://bmi.readthedocs.io>`_.
+
+.. image:: https://zenodo.org/badge/179283861.svg
+    :target: https://zenodo.org/badge/latestdoi/179283861
+    :alt: DOI
+
+.. image:: https://github.com/csdms/bmi-python/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/csdms/bmi-python/actions/workflows/test.yml
+    :alt: Build Status
+
+.. image:: https://anaconda.org/conda-forge/bmipy/badges/version.svg
+    :target: https://anaconda.org/conda-forge/bmipy
+    :alt: Anaconda-Server Badge
+
+.. image:: https://anaconda.org/conda-forge/bmipy/badges/platforms.svg
+    :target: https://anaconda.org/conda-forge/bmipy
+    :alt: Anaconda-Server Badge
+
+.. image:: https://anaconda.org/conda-forge/bmipy/badges/downloads.svg
+    :target: https://anaconda.org/conda-forge/bmipy
+    :alt: Anaconda-Server Badge
 
 Install
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,38 @@
+[metadata]
+name = bmipy
+description = Basic Model Interface for Python
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = Eric Hutton
+author_email = huttone@colorado.edu
+license = MIT
+license_files = LICENSE
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Topic :: Scientific/Engineering :: Hydrology
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Scientific/Engineering :: Physics
+url = https://github.com/csdms/bmi-python
+download_url = https://pypi.org/project/xmipy/
+
+[options]
+packages = find:
+install_requires =
+    black
+    click
+    jinja2
+    numpy
+
+[options.entry_points]
+console_scripts =
+    bmipy-render = bmipy.cmd:main
+
 [pylint]
 disable = line-too-long,bad-continuation
 

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,12 @@
-from setuptools import find_packages, setup
+import os.path
+import sys
+from setuptools import setup
+
+sys.path.append(os.path.dirname(__file__))
 
 import versioneer
 
-
 setup(
-    name="bmipy",
     version=versioneer.get_version(),
-    description="Basic Model Interface for Python",
-    long_description=open("README.rst").read(),
-    author="Eric Hutton",
-    author_email="huttone@colorado.edu",
-    url="http://csdms.colorado.edu",
-    classifiers=[
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Topic :: Scientific/Engineering :: Physics",
-    ],
-    setup_requires=["setuptools"],
-    install_requires=["black", "click", "jinja2", "numpy"],
-    packages=find_packages(),
     cmdclass=versioneer.get_cmdclass(),
-    entry_points={"console_scripts": ["bmipy-render=bmipy.cmd:main"]},
 )


### PR DESCRIPTION
Use a declarative configuration `setup.cfg` [described here](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html) to move most static metadata from `setup.py`, which is now only used to support versioneer. Other changes:

- This GitHub repo was not described in [PyPI](https://pypi.org/project/bmipy/), now updated with `url`
- README.rst had syntax errors in markup and would not be rendered on PyPI, fixed using conventional RST markup for image
- Add `pyproject.toml` to describe build system requirements
- Modernize `Makefile`