### PR TITLE
Drop python 3.6, test 3.10 and 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,9 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
 
       - name: Show conda installation info
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,9 +13,11 @@ classifiers =
     Topic :: Scientific/Engineering :: Hydrology
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Physics
 url = https://github.com/csdms/bmi-python
@@ -23,6 +25,7 @@ download_url = https://pypi.org/project/xmipy/
 
 [options]
 packages = find:
+python_requires = >=3.7
 install_requires =
     black
     click

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ sys.path.append(os.path.dirname(__file__))
 import versioneer
 
 setup(
+    name="bmipy",  # need by GitHub dependency graph
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
 )


### PR DESCRIPTION
This sets the minimum Python version to 3.7, dropping 3.6, which was not tested in this CI.

Add Python 3.10 and 3.11 to CI.

Also, address a [GitHub bug](https://github.com/orgs/community/discussions/6456) for the dependency graph, which is [currently empty](https://github.com/csdms/bmi-python/network/dependents). This is resolved by repeating the name in `setup.py`.