### PR TITLE
Move static project metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,45 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools >=61"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "bmipy"
+description = "Basic Model Interface for Python"
+readme = "README.rst"
+authors = [
+    {name = "Eric Hutton", email = "huttone@colorado.edu"},
+]
+keywords = ["BMI", "Basic Model Interface"]
+license = {text = "MIT"}
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Scientific/Engineering :: Hydrology",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+requires-python = ">=3.7"
+dependencies = [
+    "black",
+    "click",
+    "jinja2",
+    "numpy",
+]
+dynamic = ["version"]
+
+[project.scripts]
+bmipy-render = "bmipy.cmd:main"
+
+[project.urls]
+Documentation = "https://bmi.readthedocs.io"
+Source = "https://github.com/csdms/bmi-python"
+
+[tool.setuptools.packages.find]
+include = ["bmipy", "bmipy.*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,40 +1,4 @@
-[metadata]
-name = bmipy
-description = Basic Model Interface for Python
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-author = Eric Hutton
-author_email = huttone@colorado.edu
-license = MIT
-license_files = LICENSE
-classifiers =
-    Intended Audience :: Science/Research
-    License :: OSI Approved :: MIT License
-    Topic :: Scientific/Engineering :: Hydrology
-    Operating System :: OS Independent
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Programming Language :: Python :: 3.11
-    Programming Language :: Python :: Implementation :: CPython
-    Topic :: Scientific/Engineering :: Physics
-url = https://github.com/csdms/bmi-python
-download_url = https://pypi.org/project/xmipy/
-
-[options]
-packages = find:
-python_requires = >=3.7
-install_requires =
-    black
-    click
-    jinja2
-    numpy
-
-[options.entry_points]
-console_scripts =
-    bmipy-render = bmipy.cmd:main
+# See pyproject.toml for project metadata
 
 [pylint]
 disable = line-too-long,bad-continuation

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.dirname(__file__))
 
 import versioneer
 
+# See pyproject.toml for project metadata
 setup(
     name="bmipy",  # need by GitHub dependency graph
     version=versioneer.get_version(),


### PR DESCRIPTION
This PR moves the project metadata from setup.cfg to pyproject.toml as described by [PEP 621](https://peps.python.org/pep-0621/) and implemented with [setuptools](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html) >= 61.

Note that this metadata was previously moved with #12, but setuptools did not support PEP 621 at the time.