### PR TITLE
Fix broken coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,6 @@ doctest_optionflags =
 
 [run]
 omit = bmipy/_version.py
+
+[coverage:run]
+relative_files = True


### PR DESCRIPTION
This PR makes a minor change to `setup.cfg` to fix the broken coverage score.