### PR TITLE
Use Ruff instead of other lint/formatting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,59 +1,12 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 26.3.1
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.15.8
   hooks:
-  - id: black
-    name: black
-    description: "Black: The uncompromising Python code formatter"
-    entry: black
-    language: python
-    language_version: python3
-    minimum_pre_commit_version: 2.9.2
-    require_serial: true
-    types_or: [python, pyi]
-  - id: black-jupyter
-    name: black-jupyter
-    description:
-      "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
-    entry: black
-    language: python
-    minimum_pre_commit_version: 2.9.2
-    require_serial: true
-    types_or: [python, pyi, jupyter]
-    additional_dependencies: [".[jupyter]"]
-
-- repo: https://github.com/pycqa/flake8
-  rev: 7.3.0
-  hooks:
-  - id: flake8
-    additional_dependencies:
-    - flake8-bugbear
-    - flake8-comprehensions
-    - flake8-simplify
-
-- repo: https://gitlab.com/kennon.mckeever/nbhooks
-  rev: 1.0.1
-  hooks:
-  - id: nb-ensure-clean
-    name: nb-ensure-clean
-    description: Ensure that committed Jupyter notebooks contain no outputs.
-    entry: nb-ensure-clean
-    files: \.ipynb$
-    language: python
-
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.21.2
-  hooks:
-  - id: pyupgrade
-    args: [--py310-plus]
-
-- repo: https://github.com/PyCQA/isort
-  rev: 8.0.1
-  hooks:
-  - id: isort
-    name: isort (python)
-    args: [--add-import, "from __future__ import annotations"]
-    types: [python]
+    # Run the linter
+    - id: ruff-check
+      args: [ --fix ]
+    # Run the formatter
+    - id: ruff-format
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
@@ -76,16 +29,6 @@ repos:
           requirements/.*\.txt|
           .gitignore
         )
-
-- repo: https://github.com/PyCQA/pydocstyle
-  rev: 6.3.0
-  hooks:
-  - id: pydocstyle
-    files: bmipy/.*\.py$
-    args:
-    - --convention=numpy
-    - --add-select=D417
-    additional_dependencies: [".[toml]"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.19.1

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,5 @@
+"""Nox configuration."""
+
 from __future__ import annotations
 
 import pathlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,10 +69,31 @@ where = [
 [tool.coverage.run]
 relative_files = true
 
-[tool.isort]
-known_first_party = "bmipy"
-profile = "black"
-force_single_line = true
+[tool.ruff.lint]
+select = [
+    "B",       # flake8-bugbear
+    "C4",      # flake8-comprehensions
+    "C90",     # mccabe
+    "D",       # pydocstyle
+    "E", "W",  # pycodestyle
+    "F",       # Pyflakes
+    "FA",      # flake8-future-annotations
+    "I",       # isort
+    # "SIM",   # flake8-simplify
+    "UP",      # pyupgrade
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**.py" = ["D"]
+
+[tool.ruff.lint.isort]
+force-single-line = true
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[flake8]
-exclude = build, .nox
-max-line-length = 88
-max-complexity = 10


### PR DESCRIPTION
This PR uses [Ruff](https://docs.astral.sh/ruff/) to replace several lint and formatting tools. Ruff is modern and very fast.

- Replace Black with [the Ruff Formatter](https://docs.astral.sh/ruff/formatter/#the-ruff-formatter), which incurs a minor change to whitespace.
- Replace flake8 with several Ruff rules.
- Replace pyupgrade with UP rule.
- Replace reorder-python-imports with Ruff I (isort) and FA (flake8-future-annotations) rules. This change modified some of the code, combining imports from a single module into one line.
- Replace pydocstyle with D rule.

Other changes:

- Remove nb-ensure-clean pre-commit, since there are no `*.ipynb` files in this repo
