### PR TITLE
Use setup-python gha instead of miniconda

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
+      - name: Use Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
 
       - name: Test
         run: |

--- a/noxfile.py
+++ b/noxfile.py
@@ -56,7 +56,7 @@ def locks(session: nox.Session) -> None:
         session.log(f"updated {ROOT / folder / 'requirements.txt'!s}")
 
 
-@nox.session(name="sync-requirements", python="3.11", venv_backend="conda")
+@nox.session(name="sync-requirements")
 def sync_requirements(session: nox.Session) -> None:
     """Sync requirements.in with pyproject.toml."""
     with open("requirements.in", "w") as fp:


### PR DESCRIPTION
We had been using the *onda-incubator/setup-miniconda* GitHub Action when all we really needed was *setup-python*, so I've changed our workflow to use the faster *setup-python* gha.