### PR TITLE
Manage package version through pyproject metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "bmipy"
+version = "2.0.2.dev0"
 requires-python = ">=3.10"
 description = "Basic Model Interface for Python"
 license = "MIT"
@@ -32,7 +33,6 @@ dependencies = [
     "numpy",
 ]
 dynamic = [
-    "version",
     "readme",
 ]
 
@@ -53,9 +53,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.dynamic.readme]
 file = "README.md"
 content-type = "text/markdown"
-
-[tool.setuptools.dynamic.version]
-attr = "bmipy._version.__version__"
 
 [tool.setuptools.packages.find]
 where = [

--- a/src/bmipy/_version.py
+++ b/src/bmipy/_version.py
@@ -1,3 +1,9 @@
 from __future__ import annotations
 
-__version__ = "2.0.2.dev0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version
+
+try:
+    __version__ = version("bmipy")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"


### PR DESCRIPTION
I think it's easier to manage the package version through the static metadata in *pyproject.toml*.