### PR TITLE
Fix ci by removing unsupported nox flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install nox
-          nox --non-interactive --error-on-missing-interpreter -s test
+          nox -s test
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
The CI began failing with the following error,
```
nox: error: unrecognized arguments: --error-on-missing-interpreter
```
This option, apparently, is no longer a thing and it wasn't necessary, anyway, so I removed it. 