### PR TITLE
Update license metadata for PEP639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 name = "bmipy"
 requires-python = ">=3.10"
 description = "Basic Model Interface for Python"
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = [
     "BMI",
     "Basic Model Interface",
@@ -15,7 +17,6 @@ maintainers = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
@@ -32,9 +33,6 @@ dynamic = [
     "version",
     "readme",
 ]
-
-[project.license]
-text = "MIT"
 
 [project.scripts]
 bmipy-render = "bmipy._cmd:main"


### PR DESCRIPTION
I've updated the license metadata in *pyproject.toml* to follow PEP639.