### PR TITLE
CI/coverage tooling clean up

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,3 @@ jobs:
         with:
           parallel: true
           flag-name: py${{ matrix.python-version }}-${{ matrix.os }}
-
-          debug: true
-
-  coveralls_finish:
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Coveralls Finished
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          parallel-finished: true
-          debug: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import pathlib
 import shutil
 
@@ -16,14 +15,16 @@ def test(session: nox.Session) -> None:
     session.install("-r", "requirements/requires.txt", "-r", "requirements/testing.txt")
     session.install(".", "--no-deps")
 
-    args = ["--cov", PROJECT, "-vvv"] + session.posargs
-
-    if "CI" in os.environ:
-        args.append(f"--cov-report=xml:{ROOT.absolute()!s}/coverage.xml")
-    session.run("pytest", *args)
-
-    if "CI" not in os.environ:
-        session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run(
+        "coverage",
+        "run",
+        "--source=bmipy,tests",
+        "--branch",
+        "--module",
+        "pytest",
+    )
+    session.run("coverage", "report", "--ignore-errors", "--show-missing")
+    session.run("coverage", "xml", "-o", "coverage.xml")
 
 
 @nox.session(name="test-cli")

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,3 +1,2 @@
-coveralls==3.3.1
-pytest-cov==4.1.0
-pytest==7.4.4
+coverage==7.13.5
+pytest==9.0.2


### PR DESCRIPTION
Replace *coveralls* with *codecov* and simplify coverage in *nox*
* remove coveralls and pytest-cov
* run coverage using coverage directly